### PR TITLE
Bennu script updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+pybennu_develop.deb
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-pybennu_develop.deb
 .vscode/
+overlays/bennu/*.deb

--- a/scripts/aptly
+++ b/scripts/aptly
@@ -1,9 +1,13 @@
 set -x
-apt install -y gnupg2 lsb-release
+
 mv /etc/apt/sources.list /etc/apt/sources.list_backup
-. /etc/lsb-release
+
+. /etc/os-release
+
 cat <<EOF >> /etc/apt/sources.list
-deb [arch=amd64 trusted=yes] http://archive.ubuntu.com/ubuntu/ focal main restricted universe
+deb [arch=amd64 trusted=yes] http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME} main restricted universe
 deb [arch=amd64 trusted=yes] https://apt.sceptre.dev /
 EOF
+
+export DEBIAN_FRONTEND=noninteractive
 apt-get update

--- a/scripts/aptly
+++ b/scripts/aptly
@@ -1,13 +1,23 @@
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
 mv /etc/apt/sources.list /etc/apt/sources.list_backup
 
 . /etc/os-release
 
 cat <<EOF >> /etc/apt/sources.list
 deb [arch=amd64 trusted=yes] http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME} main restricted universe
+deb [arch=amd64 trusted=yes] http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME}-updates main restricted universe
+deb [arch=amd64 trusted=yes] http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME}-security main restricted universe
+EOF
+
+apt-get update
+apt-get install -y ca-certificates apt-transport-https
+apt-get clean
+
+mkdir -p /etc/apt/sources.list.d/
+cat <<EOF >> /etc/apt/sources.list.d/aptly.list
 deb [arch=amd64 trusted=yes] https://apt.sceptre.dev /
 EOF
 
-export DEBIAN_FRONTEND=noninteractive
 apt-get update

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -7,8 +7,14 @@ ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
 
 apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" apt-utils
 
-# TODO: man pages?
-apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv pybennu python3 python3-pip python3-setuptools python3-twisted python3-wheel socat systemd-timesyncd tcpdump tmux telnet vsftpd wget git nano vim jq
+# man pages. They only add ~10-20MB to the image size.
+apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" man-db manpages-posix manpages-dev
+
+# NOTE: the phenix ntp app by default will configure ntp on clients by injecting /etc/ntp.conf
+# However, ntp isn't installed by default anymore on bennu. Therefore, we install it here.
+# systemd-timesyncd
+# NOTE: bennu and pybennu come from apt.sceptre.dev, which is built from the GitHub Action (CI pipeline)
+apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu pybennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp
 
 # Install Python dependencies
 export PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -2,7 +2,10 @@ set -x
 
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
+export PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# TODO: this should be UTC
+# ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
 ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
 
 apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" apt-utils
@@ -12,15 +15,16 @@ apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" 
 
 # NOTE: the phenix ntp app by default will configure ntp on clients by injecting /etc/ntp.conf
 # However, ntp isn't installed by default anymore on bennu. Therefore, we install it here.
-# systemd-timesyncd
 # NOTE: bennu and pybennu come from apt.sceptre.dev, which is built from the GitHub Action (CI pipeline)
 apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu pybennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp
+apt-get autoremove -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+
+# apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel python3-dev socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp
+# apt-get install -y --no-install-recommends cmake gcc g++ build-essential make libunwind-dev libunwind8
+# dpkg -i /pybennu.deb
 
 # Install Python dependencies
-export PIP_DISABLE_PIP_VERSION_CHECK=1
 pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --no-cache-dir ipython pymodbus
-
-apt-get autoremove -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
 # Set sticky bit on brash binary
 brash=$(which bennu-brash)

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -50,6 +50,10 @@ echo "root:SiaSd3te" | chpasswd
 adduser sceptre --UID 1001 --gecos "" --shell /usr/bin/bennu-brash --disabled-login
 echo "sceptre:sceptre" | chpasswd
 
+# https://serverfault.com/a/1016367
+systemctl disable systemd-timesyncd
+systemctl enable ntp
+
 # phenix hostname
 echo "phenix" > /etc/hostname
 sed -i 's/127.0.1.1 .*/127.0.1.1 phenix/' /etc/hosts

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -56,18 +56,3 @@ systemctl enable ntp
 
 # Ensure /etc is owned by root, as god intended
 chown -R root:root /etc
-
-# phenix hostname
-echo "phenix" > /etc/hostname
-sed -i 's/127.0.1.1 .*/127.0.1.1 phenix/' /etc/hosts
-cat > /etc/motd <<EOF
-
-██████╗ ██╗  ██╗███████╗███╗  ██╗██╗██╗  ██╗
-██╔══██╗██║  ██║██╔════╝████╗ ██║██║╚██╗██╔╝
-██████╔╝███████║█████╗  ██╔██╗██║██║ ╚███╔╝
-██╔═══╝ ██╔══██║██╔══╝  ██║╚████║██║ ██╔██╗
-██║     ██║  ██║███████╗██║ ╚███║██║██╔╝╚██╗
-╚═╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚══╝╚═╝╚═╝  ╚═╝
-
-EOF
-echo "\nBuilt with phenix image on $(date)\n\n" >> /etc/motd

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -4,10 +4,19 @@ export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
 
 ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
-apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv pybennu python3 python3-pip python3-setuptools python3-twisted python3-wheel socat systemd-timesyncd tcpdump tmux telnet vsftpd wget iperf3
 
-pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org ipython pymodbus
-apt-get autoremove -y
+apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" apt-utils
+
+# TODO: man pages?
+apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv pybennu python3 python3-pip python3-setuptools python3-twisted python3-wheel socat systemd-timesyncd tcpdump tmux telnet vsftpd wget git nano vim jq
+
+# Install Python dependencies
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --no-cache-dir ipython pymodbus
+
+apt-get autoremove -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+
+# Set sticky bit on brash binary
 brash=$(which bennu-brash)
 if ! [ -z "$brash" ]
 then

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -19,7 +19,7 @@ apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" 
 apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu pybennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp ca-certificates libusb-1.0-0
 apt-get autoremove -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
-# apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel python3-dev socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp
+# apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel python3-dev socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp ca-certificates libusb-1.0-0
 # apt-get install -y --no-install-recommends cmake gcc g++ build-essential make libunwind-dev libunwind8
 # dpkg -i /pybennu.deb
 
@@ -67,5 +67,6 @@ echo "sceptre:sceptre" | chpasswd
 systemctl disable systemd-timesyncd
 systemctl enable ntp
 
-# Ensure /etc is owned by root, as god intended
+# Ensure /etc is owned by root
+# This fixes funkyness if overlay files on the host running the build aren't owned by root
 chown -R root:root /etc

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -1,6 +1,8 @@
 set -x
+
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
+
 ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
 apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv pybennu python3 python3-pip python3-setuptools python3-twisted python3-wheel socat systemd-timesyncd tcpdump tmux telnet vsftpd wget iperf3
 
@@ -11,6 +13,8 @@ if ! [ -z "$brash" ]
 then
     chmod u+s $brash
 fi
+
+# Configure FTP service and allow "sceptre" user
 sed -i 's/pam_service_name=vsftpd/pam_service_name=ftp/g' /etc/vsftpd.conf
 echo "sceptre" >> /etc/vsftpd.allowed_users
 cat <<EOF >> /etc/vsftpd.conf
@@ -23,9 +27,14 @@ userlist_deny=NO
 userlist_enable=YES
 userlist_file=/etc/vsftpd.allowed_users
 EOF
+
+# Change root's password
 echo "root:SiaSd3te" | chpasswd
+
+# Add "sceptre" user, set their login shell to Brash
 adduser sceptre --UID 1001 --gecos "" --shell /usr/bin/bennu-brash --disabled-login
 echo "sceptre:sceptre" | chpasswd
+
 # phenix hostname
 echo "phenix" > /etc/hostname
 sed -i 's/127.0.1.1 .*/127.0.1.1 phenix/' /etc/hosts

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -54,6 +54,9 @@ echo "sceptre:sceptre" | chpasswd
 systemctl disable systemd-timesyncd
 systemctl enable ntp
 
+# Ensure /etc is owned by root, as god intended
+chown -R root:root /etc
+
 # phenix hostname
 echo "phenix" > /etc/hostname
 sed -i 's/127.0.1.1 .*/127.0.1.1 phenix/' /etc/hosts

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -33,7 +33,7 @@ popd || exit
 rm -rf /tmp/labjack
 
 # Install Python dependencies
-pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --no-cache-dir ipython pymodbus
+pip3 install --no-cache-dir ipython pymodbus
 
 # Set sticky bit on brash binary
 brash=$(which bennu-brash)


### PR DESCRIPTION
### bennu
- Remove `iperf3`
- Add `nano`, `vim`, `jq`, and ensure `git` is included
- Install `man` pages. They only add ~10-20MB to the final image size, and make life better.
- Don't cache python packages, which reduces the image size
- Fix build getting stuck at the autoremove step with a prompt to replace a config file
- Remove redundant parts of bennu script at the end, such as setting `/etc/motd`. These are already done (with identical code) in `POSTBUILD_PHENIX_HOSTNAME` which is part of "minbase" variant in phenix image.
- Install `ntp` instead of `systemd-timesyncd`, and ensure the `systemd-timesyncd` service is disabled. The `ntp` phenix app by default will configure ntp on clients by injecting `/etc/ntp.conf`. However, ntp isn't installed by default anymore on bennu. Therefore, we install it here.
- Ensure `/etc` is owned by `root`. This fixes funkyness if overlay files on the host running the build aren't owned by root.

### aptly
- remove need for `lsb-release` by using `/etc/os-release`
- remove `gnupg2` (no longer needed)
- ensure `/etc/apt/sources.list.d/` exists

### general
- add `.gitignore`