### PR TITLE
Create image build github action

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,84 @@
+name: image-build
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  schedule:
+    - cron: '11 11 * * WED'
+jobs:
+  # save minicc and minirouter as artifacts to inject in image later
+  get-miniccc:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sandialabs/sceptre-phenix/minimega:main
+    steps:
+      - name: upload miniccc and minirouter
+        uses: actions/upload-artifact@v4
+        with:
+          name: miniexes
+          path: |
+            /opt/minimega/bin/miniccc
+            /opt/minimega/bin/minirouter
+  # build using phenix image builder
+  build:
+    needs: get-miniccc
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sandialabs/sceptre-phenix/phenix:main
+      options: --privileged # needed for kernel device-mapper permissions
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      # Runs a set of commands using the runners shell
+      - name: get miniexes
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: miniexes
+
+      # add the miniccc binary
+      # the phenix base scripts already include the systemd service
+      - name: add miniccc
+        run: |
+          mkdir -p ./overlays/miniccc/opt/minimega/bin
+          cp ./miniccc ./overlays/miniccc/opt/minimega/bin
+          chmod +x ./overlays/miniccc/opt/minimega/bin/miniccc
+
+      - name: bennu image build
+        run: |
+          phenix version
+          mkdir ./out
+          phenix image create -O ./overlays/bennu,./overlays/brash,./overlays/miniccc -T ./scripts/aptly,./scripts/bennu --format qcow2 --release focal -c bennu --size 10G
+          phenix image build bennu -o ./out -x
+
+      # upload bennu qc2 as artifact
+      - name: upload qc2
+        uses: actions/upload-artifact@v4
+        with:
+          name: bennu.qc2
+          path: ./out/bennu.qc2
+  # upload to github release
+  release:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: get bennu image
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: bennu.qc2
+      - name: create release
+        uses: ncipollo/release-action@v1.15.0
+        with:
+          name: release-${{ steps.date.outputs.date }}
+          artifacts: bennu.qc2
+          tag: release-${{ steps.date.outputs.date }}
+          commit: main

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -1,0 +1,18 @@
+# This workflow runs weekly to clean up releases and tags older than 90 days
+name: release-cleanup
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Run on schedule
+  schedule:
+    - cron: '11 12 * * WED'
+jobs:
+  release-cleanup:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/delete-stale-releases@v1.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          delete_tags: true
+          keep_latest_days: 90

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -16,7 +16,7 @@ apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" 
 # NOTE: the phenix ntp app by default will configure ntp on clients by injecting /etc/ntp.conf
 # However, ntp isn't installed by default anymore on bennu. Therefore, we install it here.
 # NOTE: bennu and pybennu come from apt.sceptre.dev, which is built from the GitHub Action (CI pipeline)
-apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu pybennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp ca-certificates libusb-1.0-0
+apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" libzmq5-dev bennu pybennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp ca-certificates libusb-1.0-0
 apt-get autoremove -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
 # apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" bennu collectd ftp pv python3 python3-pip python3-setuptools python3-twisted python3-wheel python3-dev socat tcpdump tmux telnet vsftpd wget git nano vim jq ntp ca-certificates libusb-1.0-0


### PR DESCRIPTION
This creates the initial framework for qc2 image building via github actions, and builds bennu.qc2 to start with.

Releases are created weekly on Wednesdays, and an auto cleanup job deletes releases older than 90 days.

This also fixes a dependency issue in the bennu image build