### PR TITLE
Add ubuntu base image and various fixes

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -110,17 +110,22 @@ jobs:
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: get images from artifacts
-        uses: actions/download-artifact@v4.1.8
-        with:
-          pattern: "*.qc2"
-          path: ./images
-          merge-multiple: true
+      # - name: get images from artifacts
+      #   uses: actions/download-artifact@v4.1.8
+      #   with:
+      #     pattern: "*.qc2"
+      #     path: ./images
+      #     merge-multiple: true
 
       - name: create release
         uses: ncipollo/release-action@v1.15.0
         with:
           name: release-${{ steps.date.outputs.date }}
-          artifacts: "./images/*.qc2"
+          body: |
+            Images are too large to be attached to the release directly.  
+            For the full set of downloadable images, visit the [artifacts page](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          # artifacts: "./images/*.qc2"
           tag: release-${{ steps.date.outputs.date }}
           commit: main
+          generateReleaseNotes: true
+          makeLatest: true

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -9,7 +9,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
-    - cron: '11 11 * * WED'
+    - cron: "11 11 * * WED"
 jobs:
   # save minicc and minirouter as artifacts to inject in image later
   get-miniccc:
@@ -25,11 +25,11 @@ jobs:
             /opt/minimega/bin/miniccc
             /opt/minimega/bin/minirouter
   # build using phenix image builder
-  build:
+  build-bennu:
     needs: get-miniccc
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sandialabs/sceptre-phenix/phenix:main
+      image: ghcr.io/sandialabs/sceptre-phenix/phenix:31ce034
       options: --privileged # needed for kernel device-mapper permissions
 
     steps:
@@ -62,23 +62,65 @@ jobs:
         with:
           name: bennu.qc2
           path: ./out/bennu.qc2
+  build-ubuntu:
+    needs: get-miniccc
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sandialabs/sceptre-phenix/phenix:31ce034
+      options: --privileged # needed for kernel device-mapper permissions
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      # Runs a set of commands using the runners shell
+      - name: get miniexes
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: miniexes
+
+      # add the miniccc binary
+      # the phenix base scripts already include the systemd service
+      - name: add miniccc
+        run: |
+          mkdir -p ./overlays/miniccc/opt/minimega/bin
+          cp ./miniccc ./overlays/miniccc/opt/minimega/bin
+          chmod +x ./overlays/miniccc/opt/minimega/bin/miniccc
+
+      - name: ubuntu image build
+        run: |
+          phenix version
+          mkdir ./out
+          phenix image create -O ./overlays/miniccc -T ./scripts/ubuntu,./scripts/ubuntu-user --format qcow2 --release noble -c ubuntu --size 10G
+          phenix image build ubuntu -o ./out -x
+
+      # upload bennu qc2 as artifact
+      - name: upload qc2
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu.qc2
+          path: ./out/ubuntu.qc2
   # upload to github release
   release:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    needs: build
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    needs:
+      - build-bennu
+      - build-ubuntu
     runs-on: ubuntu-latest
     steps:
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: get bennu image
+      - name: get images from artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: bennu.qc2
+          pattern: "*.qc2"
+          path: ./images
+          merge-multiple: true
+
       - name: create release
         uses: ncipollo/release-action@v1.15.0
         with:
           name: release-${{ steps.date.outputs.date }}
-          artifacts: bennu.qc2
+          artifacts: "./images/*.qc2"
           tag: release-${{ steps.date.outputs.date }}
           commit: main

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Basic Ubuntu image with a few packages added. The Ubuntu version built can be ch
 The max size of the VM disk in the example below is set to 10 gigabytes, but can be customized as needed. Running the built command will result in `/phenix/ubuntu.qc2`.
  
 ```bash
-phenix image create -T /phenix/vmdb2/scripts/aptly,/phenix/vmdb2/scripts/ubuntu --format qcow2 --release focal -c ubuntu --size 10G
+phenix image create -T /phenix/vmdb2/scripts/ubuntu,/phenix/vmdb2/scripts/ubuntu-user --format qcow2 --release noble -c ubuntu --size 10G
 phenix image build ubuntu -o /phenix -c -x
 ```
 

--- a/scripts/ubuntu
+++ b/scripts/ubuntu
@@ -1,27 +1,46 @@
-set -x
+#!/bin/sh
 
-apt-get update
+set -ex
 
-DEBIAN_FRONTEND=noninteractive apt-get install -y gcc autoconf libtool linux-image-generic linux-headers-generic initramfs-tools net-tools isc-dhcp-client openssh-server init iputils-ping vim less netbase curl ethtool rsync ifupdown dbus nmap tcpdump iptables build-essential libpcap-dev libpcre3-dev libdumbnet-dev bison flex zlib1g-dev liblzma-dev openssl libssl-dev wget arptables libluajit-5.1-dev libnghttp2-dev libdnet xfce4 xorg xserver-xorg-input-all dbus-x11 xserver-xorg-video-qxl xserver-xorg-video-vesa xinit xfce4-terminal qupzilla python3 python3-pip python3-distutils python3-scapy python3-bitstring tshark tmux ettercap-common ettercap-text-only python3-numpy python3-scipy python3-matplotlib wireshark python3-twisted python3-plotly apache2
+# Load VERSION_CODENAME to use when adding apt repos
+. /etc/os-release
 
+## Save this for later because future ubuntu versions will require this format
+# cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+# Types: deb
+# URIs: http://archive.ubuntu.com/ubuntu
+# Suites: ${VERSION_CODENAME} ${VERSION_CODENAME}-updates ${VERSION_CODENAME}-backports
+# Components: main universe restricted multiverse
+# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+# ## Ubuntu security updates. Aside from URIs and Suites,
+# ## this should mirror your choices in the previous section.
+# Types: deb
+# URIs: http://security.ubuntu.com/ubuntu
+# Suites: ${VERSION_CODENAME}-security
+# Components: main universe restricted multiverse
+# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+# EOF
+
+# Add updates, security, and backports
+cat <<EOF > /etc/apt/sources.list
+deb http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME} main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME}-updates main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME}-security main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME}-backports main restricted universe multiverse
+EOF
+
+export DEBIAN_FRONTEND=noninteractive
+apt update
+apt upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+apt install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" net-tools openssh-server iputils-ping vim less nano micro ca-certificates sudo iptables
+
+systemctl enable ssh
+
+# apt cleanup
 rm -rf /var/cache/apt/archives
-
-kernel=$(uname -r)
-update-initramfs -c -k $kernel
-
-echo "ubuntu" > /etc/hostname
-sed -i 's/127.0.1.1 .*/127.0.1.1 ubuntu/' /etc/hosts
-
-#echo -e "password\npassword" | passwd root
-sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth
-sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-sed -i 's/PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
-passwd -d root
-sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config
-sed -i 's/#PermitEmptyPasswords yes/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
-
 apt clean
+apt autoremove
 
-mkdir /media/cdrom
-echo "/dev/sda1   /              ext2 defaults             1 1
-/dev/cdrom  /media/cdrom   auto ro,noauto,user,exec  0 0" > /etc/fstab
+# add phenix hostname
+echo '127.0.1.1 phenix' > /etc/hosts

--- a/scripts/ubuntu-user
+++ b/scripts/ubuntu-user
@@ -1,0 +1,9 @@
+# adds a non-root user account called "ubuntu" with sudo permissions
+
+set -ex
+
+# don't fail if user already exists
+useradd --create-home --shell /bin/bash ubuntu || true
+usermod -aG sudo ubuntu
+echo 'ubuntu   ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/ubuntu
+echo 'ubuntu:ubuntu' | chpasswd


### PR DESCRIPTION
- Add ubuntu noble base image build
- Lock phenix image version (workaround for https://github.com/sandialabs/sceptre-phenix/issues/207)
- Change release logic to link to artifacts page, because images over 2GB are too large to attach to release directly