### PR TITLE
Update bennu base image to ubuntu 22.04

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           phenix version
           mkdir ./out
-          phenix image create -O ./overlays/bennu,./overlays/brash,./overlays/miniccc -T ./scripts/aptly,./scripts/bennu --format qcow2 --release focal -c bennu --size 10G
+          phenix image create -O ./overlays/bennu,./overlays/brash,./overlays/miniccc -T ./scripts/aptly,./scripts/bennu --format qcow2 --release jammy -c bennu --size 10G
           phenix image build bennu -o ./out -x
 
       # upload bennu qc2 as artifact

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Official SCEPTRE image used for running bennu in experiments (includes brash she
 The max size of the VM disk in the example below is set to 10 gigabytes, but can be customized as needed. Running the built command will result in `/phenix/bennu.qc2`.
 
 ```bash
-phenix image create -O /phenix/vmdb2/overlays/bennu,/phenix/vmdb2/overlays/brash -T /phenix/vmdb2/scripts/aptly,/phenix/vmdb2/scripts/bennu --format qcow2 --release focal -c bennu --size 10G
+phenix image create -O /phenix/vmdb2/overlays/bennu,/phenix/vmdb2/overlays/brash -T /phenix/vmdb2/scripts/aptly,/phenix/vmdb2/scripts/bennu --format qcow2 --release jammy -c bennu --size 10G
 phenix image build bennu -o /phenix -c -x
 ```
 

--- a/scripts/bennu
+++ b/scripts/bennu
@@ -1,4 +1,4 @@
-set -x
+set -ex
 
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
@@ -11,7 +11,7 @@ ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
 apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" apt-utils
 
 # man pages. They only add ~10-20MB to the image size.
-apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" man-db manpages-posix manpages-dev
+apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" man-db  manpages-dev
 
 # NOTE: the phenix ntp app by default will configure ntp on clients by injecting /etc/ntp.conf
 # However, ntp isn't installed by default anymore on bennu. Therefore, we install it here.
@@ -25,12 +25,13 @@ apt-get autoremove -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="-
 
 # install labjack libraries for pybennu-siren
 # NOTE: pushd/popd cannot be used here due to the fact this isn't bash
+apt-get install -y --no-install-recommends unzip
 PREV="$(pwd)"
 mkdir -p /tmp/labjack
 cd /tmp/labjack
-wget -q https://files.labjack.com/installers/LJM/Linux/x64/release/labjack_ljm_software_2019_07_16_x86_64.tar.gz -O labjack.tar.gz
-tar -xaf labjack.tar.gz
-./labjack_ljm_software_2019_07_16_x86_64/labjack_ljm_installer.run
+wget -q https://files.labjack.com/installers/LJM/Linux/x64/beta/LabJack-LJM_2025-02-12.zip -O labjack.zip
+unzip labjack.zip
+./labjack_ljm_installer.run --noprogress --nox11 --accept --nodiskspace || true
 cd "$PREV"
 rm -rf /tmp/labjack
 
@@ -62,7 +63,7 @@ EOF
 echo "root:SiaSd3te" | chpasswd
 
 # Add "sceptre" user, set their login shell to Brash
-adduser sceptre --UID 1001 --gecos "" --shell /usr/bin/bennu-brash --disabled-login
+adduser sceptre --UID 1001 --gecos "" --shell /usr/bin/bennu-brash --disabled-login || true
 echo "sceptre:sceptre" | chpasswd
 
 # https://serverfault.com/a/1016367
@@ -72,3 +73,5 @@ systemctl enable ntp
 # Ensure /etc is owned by root
 # This fixes funkyness if overlay files on the host running the build aren't owned by root
 chown -R root:root /etc
+
+apt-get -y clean || true


### PR DESCRIPTION
# Update bennu base image to ubuntu 22.04

## Description
- update base to ubuntu 22.04
- update labjack-ljm library
- force bennu build script to stop on errors (to make it easier to identify problems)

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
