### PR TITLE
fix: use variable for workflow repo name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Contributing to SCEPTRE Phenix Images
 
 Thank you for your interest in contributing to SCEPTRE Phenix Images! We welcome contributions from everyone and appreciate your efforts to improve our project. This guide will help you understand how to contribute effectively.
 
-> Note: A failure to follow this guide will result in delay of PRs until there is compliance. 
+> Note: A failure to follow this guide will result in delay of PRs until there is compliance.
 
 ## Table of Contents
 
@@ -54,7 +54,7 @@ If you encounter a bug or have a feature request, please open an issue in the [I
 
 ### Suggesting Enhancements
 
-We welcome suggestions for improvements! Please open an issue to discuss your ideas before implementing them. 
+We welcome suggestions for improvements! Please open an issue to discuss your ideas before implementing them.
 
 ### Submitting Code
 
@@ -126,12 +126,12 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
     In the interactive rebase interface, change the word `pick` to `squash` (or `s`) for all commits you want to combine into the first commit. After saving and closing the editor, you will be prompted to create a new commit message. Write a single, comprehensive commit message that summarizes all the changes.
 
 5. **Push to Your Fork**: If you had to rebase, you may need to force push your changes to your forked repository.
-    
+
     Example:
     ```bash
     git push origin feat/add-user-authentication --force
     ```
-    
+
 6. **Open a Pull Request**: Go to the original repository and open a [pull request](https://github.com/sandialabs/sceptre-phenix-images/pulls). Provide a clear description of your changes and reference any related issues.
 
 ## License

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -29,6 +29,6 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           older-than: 90 day
-          packages: sceptre-phenix-images/${{ matrix.build }}.qc2
+          packages: ${{ github.event.repository.name }}/${{ matrix.build }}.qc2
           keep-n-tagged: 5
           exclude-tags: latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Images
 
+[![image-build](https://github.com/sandialabs/sceptre-phenix-images/actions/workflows/image-build.yml/badge.svg)](https://github.com/sandialabs/sceptre-phenix-images/actions/workflows/image-build.yml) [![release-cleanup](https://github.com/sandialabs/sceptre-phenix-images/actions/workflows/release-cleanup.yml/badge.svg)](https://github.com/sandialabs/sceptre-phenix-images/actions/workflows/release-cleanup.yml)
+
 This repository contains configuration files, overlays, and scripts used by
 `phenix image`, a tool used to quickly generate debian-based qcow2 VM images.
 `phenix image` is a wrapper of the [vmdb2](https://vmdb2.liw.fi/) tool which,


### PR DESCRIPTION
# Fix workflow cleanup on forks

## Description
Changed the hard-coded `sceptre-phenix-images` with `github.event.repository.name` variable.

- Added action status badges to README
- Removed whitespace in CONTRIBUTORS (ocd)

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.

## Additional Notes
n/a
