### PR TITLE
feat: add minirouter and soaptools image builds

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,7 +18,18 @@ jobs:
   build-images:
     strategy:
       matrix:
-        build: [bookworm, kali, jammy, noble, bennu, docker-hello-world, ntp, vyos]
+        build:
+          [
+            bookworm,
+            kali,
+            jammy,
+            noble,
+            bennu,
+            docker-hello-world,
+            ntp,
+            vyos,
+            minirouter,
+          ]
     runs-on: ubuntu-latest
     steps:
       # Checkout repository code
@@ -31,6 +42,7 @@ jobs:
         with:
           packages: qemu-utils
           version: 1.0
+
       # Pull docker containers
       - name: pull docker containers
         run: |
@@ -38,6 +50,7 @@ jobs:
           docker pull ghcr.io/sandialabs/sceptre-phenix/minimega:main
           docker tag ghcr.io/sandialabs/sceptre-phenix/phenix:main phenix:latest
           docker tag ghcr.io/sandialabs/sceptre-phenix/minimega:main minimega:latest
+
       # Start docker containers
       - name: wget docker-compose.yml
         uses: wei/wget@v1
@@ -50,13 +63,25 @@ jobs:
           docker compose -f docker-compose.yml up -d phenix
           echo "Waiting for services to start..."
           sleep 5
-      # Extract miniccc
-      - name: get miniccc
-        run: docker cp minimega:/opt/minimega/bin/miniccc ./
+
+      # Extract miniccc and minirouter binaries
+      - name: get miniccc and minirouter
+        run: |
+          docker cp minimega:/opt/minimega/bin/miniccc ${{ github.workspace }}
+          docker cp minimega:/opt/minimega/bin/minirouter ${{ github.workspace }}
+
+      # Remove unneeded tools to make more build space
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # skip the remove large-packages step because it takes a while
+          large-packages: false
+
       # Build the non-vyos images using phenix
       - name: ${{ matrix.build }} image build
         if: ${{ matrix.build != 'vyos' }}
         run: make ${{ matrix.build }}
+
       # Build the vyos image using custom build script
       - name: ${{ matrix.build }} image build
         if: ${{ matrix.build == 'vyos' }}
@@ -64,6 +89,7 @@ jobs:
         run: |
           sudo modprobe nbd
           sudo make ${{ matrix.build }}
+
       # Publish the built image to GitHub Container Registry using oras
       - name: publish package with oras
         # Only push package if on the default branch (e.g., main)
@@ -72,12 +98,24 @@ jobs:
         run: |
           oras login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
           oras push "ghcr.io/${{ github.repository }}/${{ matrix.build }}.qc2:${GITHUB_SHA:0:7}" ${{ matrix.build }}.qc2
-
+          # tag with branch name
+          oras tag "ghcr.io/${{ github.repository }}/${{ matrix.build }}.qc2:${GITHUB_SHA:0:7}" "${GITHUB_REF##*/}"
   # Job: Tag images after successful builds
   tag-images:
     strategy:
       matrix:
-        build: [bookworm, kali, jammy, noble, bennu, docker-hello-world, ntp, vyos]
+        build:
+          [
+            bookworm,
+            kali,
+            jammy,
+            noble,
+            bennu,
+            docker-hello-world,
+            ntp,
+            vyos,
+            minirouter,
+          ]
     # Only run on main branch for scheduled or manual workflow_dispatch events
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     needs: build-images

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -29,11 +29,14 @@ jobs:
             ntp,
             vyos,
             minirouter,
+            ubuntu-soaptools,
           ]
     runs-on: ubuntu-latest
     steps:
       # Checkout repository code
       - uses: actions/checkout@v4
+      # Create slug var for branch ref suitiable for tags
+      - uses: rlespinasse/github-slug-action@v5.2.0
       # Install oras CLI for pushing images to OCI registries
       - uses: oras-project/setup-oras@v1
       - uses: docker/setup-docker-action@v4
@@ -93,13 +96,14 @@ jobs:
       # Publish the built image to GitHub Container Registry using oras
       - name: publish package with oras
         # Only push package if on the default branch (e.g., main)
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        # or if manually triggered on a different branch so maintainers can manually push images
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           oras login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
           oras push "ghcr.io/${{ github.repository }}/${{ matrix.build }}.qc2:${GITHUB_SHA:0:7}" ${{ matrix.build }}.qc2
           # tag with branch name
-          oras tag "ghcr.io/${{ github.repository }}/${{ matrix.build }}.qc2:${GITHUB_SHA:0:7}" "${GITHUB_REF##*/}"
+          oras tag "ghcr.io/${{ github.repository }}/${{ matrix.build }}.qc2:${GITHUB_SHA:0:7}" "${GITHUB_REF_SLUG}"
   # Job: Tag images after successful builds
   tag-images:
     strategy:
@@ -115,6 +119,7 @@ jobs:
             ntp,
             vyos,
             minirouter,
+            ubuntu-soaptools,
           ]
     # Only run on main branch for scheduled or manual workflow_dispatch events
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .vscode/
 overlays/bennu/*.deb
+*.log
+*.vmdb
+./miniccc
+./minirouter
+*.qc2
+*.tar

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check_clean bookworm kali jammy noble bennu minirouter _minirouter_img docker-hello-world ntp clean
+.PHONY: help check_clean bookworm kali jammy noble bennu minirouter _minirouter_img docker-hello-world ntp ubuntu-soaptools clean
 
 .ONESHELL: # for heredoc and exit
 
@@ -87,6 +87,13 @@ _minirouter_img: # use _img to avoid conflict with minirouter binary
 	@$(INJECT_MINICCC)
 	if test -f $(CURDIR)/$(@).qc2; then $(PHENIX) image inject-miniexe $(CURDIR)/minirouter $(CURDIR)/$(@).qc2; echo "----- Injected minirouter into $(@).qc2 -----"; fi
 	@mv -f $(CURDIR)/$(@).qc2 $(CURDIR)/minirouter.qc2
+
+# Build ubuntu-soaptools.qc2	-- Ubuntu Jammy, soaptools
+ubuntu-soaptools:
+	@$(CHECK_IMAGE)
+	@$(PHENIX) image create -r jammy -v mingui -s 50G -T $(CURDIR)/scripts/atomic/ubuntu-user.sh,$(CURDIR)/scripts/soaptools.sh $(COMPRESS) $(@)
+	@$(PHENIX_IMAGE_BUILD) $(@)
+	@$(INJECT_MINICCC)
 
 ##
 ## ------------------------------------------ Administration ------------------------------------------

--- a/README.md
+++ b/README.md
@@ -175,3 +175,4 @@ the Makefile are shown below.
 | ntp | Ubuntu / jammy | [ntpd](https://linux.die.net/man/8/ntpd) | Network time protocol server | :x: |
 | vyos | VyOS / 1.5 | [VyOS](https://docs.vyos.io/en/latest/) | Open-source enterprise-grade router platform | :x: |
 | minirouter | Ubuntu / noble | miniccc/minirouter | Minimega-based router | :x: |
+| soaptools | Ubuntu / jammy | filebeat,zeek,msf | preconfigured image for the [soap-hil topology](https://github.com/sandialabs/sceptre-phenix-topologies/tree/main/soap-hil) | :white_check_mark:  |

--- a/README.md
+++ b/README.md
@@ -174,3 +174,4 @@ the Makefile are shown below.
 | docker-hello-world | Ubuntu / jammy | Docker | Shows how you can run a service (dockerd) inside the chroot image build environment | :x: |
 | ntp | Ubuntu / jammy | [ntpd](https://linux.die.net/man/8/ntpd) | Network time protocol server | :x: |
 | vyos | VyOS / 1.5 | [VyOS](https://docs.vyos.io/en/latest/) | Open-source enterprise-grade router platform | :x: |
+| minirouter | Ubuntu / noble | miniccc/minirouter | Minimega-based router | :x: |

--- a/overlays/minirouter/etc/systemd/system/miniccc.service.d/override.conf
+++ b/overlays/minirouter/etc/systemd/system/miniccc.service.d/override.conf
@@ -1,0 +1,8 @@
+# Custom Miniccc Service Configuration
+# Make sure minirouter is running before starting miniccc
+# Otherwise some minirouter settings may not be applied correctly at startup
+[Unit]
+After=minirouter.service
+
+[Service]
+ExecStartPre=/usr/bin/sleep 5s

--- a/scripts/minirouter.sh
+++ b/scripts/minirouter.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+# remove systemd-resolved because it interferes with dnsmasq
+apt remove --purge -y systemd-resolved
+
+# disable system services, minirouter starts it's own processes
+systemctl disable dnsmasq
+systemctl disable bird

--- a/scripts/soaptools.sh
+++ b/scripts/soaptools.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ex
+
+cat > /etc/apt/sources.list.d/updates.list <<EOF
+deb http://us.archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+deb http://us.archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+deb http://us.archive.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
+EOF
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends xubuntu-core epiphany-browser wireshark-gtk python3-pip python-is-python3 micro
+
+# install python dependencies for soap demo tools
+pip3 install python-snap7==1.3 dnp3-python==0.2.3b3
+
+# Install filebeat and zeek for soap scorch demo
+# if you are behind a proxy and get certificate errors, change `curl` to `curl --insecure`
+curl -LO https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.17.21-amd64.deb
+dpkg -i filebeat-7.17.21-amd64.deb
+
+## uncomment the lines below if your are behind a proxy and get certificate errors with apt
+# sudo tee /etc/apt/apt.conf.d/99-no-verify  <<EOF
+# Acquire::https::Verify-Peer "false";
+# Acquire::https::Verify-Host "false";
+# EOF
+
+echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_22.04/ /' | tee /etc/apt/sources.list.d/security:zeek.list
+
+# if you are behind a proxy and get certificate errors, change `curl` to `curl --insecure`
+curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_22.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+apt update
+DEBIAN_FRONTEND=noninteractive apt install zeek-6.0 -y
+
+# install msfconsole for soap demo
+set -e
+# if you are behind a proxy and get certificate errors, change `curl` to `curl --insecure`
+curl -L https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb | bash
+
+apt clean


### PR DESCRIPTION
# feat: add minirouter and soaptools image builds

## Description
Adds image builds for minirouter and the ubuntu-soaptools base image used in soap-hil  
Also:
- cleans runner before build to allow more build space (should fix the intermittent vyos build issues)
- Also tag images with branch name when publishing
- Allow manual workflow run by maintainers to publish images on non-default branch for testing

## Related Issue
N/a

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
