### PR TITLE
fix(minirouter): enable IP forwarding

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -86,12 +86,14 @@ jobs:
         run: make ${{ matrix.build }}
 
       # Build the vyos image using custom build script
+      # Using /mnt for more temp space for injecting miniccc
       - name: ${{ matrix.build }} image build
         if: ${{ matrix.build == 'vyos' }}
         shell: bash
         run: |
           sudo modprobe nbd
-          sudo make ${{ matrix.build }}
+          export VYOSTMP=/mnt/vyostmp
+          sudo -E make ${{ matrix.build }}
 
       # Publish the built image to GitHub Container Registry using oras
       - name: publish package with oras

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ PHENIX_IMAGE_BUILD=$(PHENIX) image build -o $(CURDIR) -c -x
 CHECK_IMAGE=if $(PHENIX) cfg list | grep Image | awk '{print $$6}' | grep "^$(@)$$" >/dev/null; then echo "\n\tphenix image already exists: '$(@)' - run 'phenix image delete $(@)' first\n"; exit; fi
 INJECT_MINICCC=if test -f $(CURDIR)/$(@).qc2; then $(PHENIX) image inject-miniexe $(CURDIR)/miniccc $(CURDIR)/$(@).qc2; echo "----- Injected miniccc into $(@).qc2 -----"; fi
 COMPRESS=-c
+# tmp dir with plenty of space to use for vyos miniccc injection
+# override with env var if needed
+VYOSTMP?=$(CURDIR)/vyostmp/
 
 # Show this help
 help:
@@ -74,7 +77,7 @@ ntp:
 # Build vyos.qc2			-- VyOS 1.5
 vyos:
 	@cd $(CURDIR)/scripts/vyos/
-	@./build-vyos.sh -m $(CURDIR)/miniccc
+	@VYOSTMP=$(VYOSTMP) ./build-vyos.sh -m $(CURDIR)/miniccc
 	@mv vyos.qc2 $(CURDIR)
 
 # Build minirouter.qc2 		-- Ubuntu Noble, minirouter

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ bookworm:
 # Build kali.qc2		-- Kali, GUI
 kali:
 	@$(CHECK_IMAGE)
-	@$(PHENIX) image create -P kali-tools-top10 -r kali-rolling -v mingui $(COMPRESS) $(@)
+	@$(PHENIX) image create -P kali-tools-top10 -r kali-rolling -v mingui -s 20G $(COMPRESS) $(@)
 	@$(PHENIX_IMAGE_BUILD) $(@)
 	@$(INJECT_MINICCC)
 

--- a/scripts/minirouter.sh
+++ b/scripts/minirouter.sh
@@ -8,3 +8,6 @@ apt remove --purge -y systemd-resolved
 # disable system services, minirouter starts it's own processes
 systemctl disable dnsmasq
 systemctl disable bird
+
+# enable ip forwarding
+echo "net.ipv4.ip_forward=1" > /etc/sysctl.d/11-ip-forwarding.conf


### PR DESCRIPTION
# fix(minirouter): enable IP forwarding

## Description
Minirouter didn't have ip forwarding enabled, this adds it via sysctl
Also fix other image builds:
- kali: make disk size larger (20G instead of 10G)
- vyos: use a separate mounted storage space (/mnt) on the runner to prevent running out of space during miniccc inject

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
