### PR TITLE
fix(vyos): revise phenix startup injects for latest vyos changes

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -42,10 +42,10 @@ jobs:
       - uses: oras-project/setup-oras@v1
       - uses: docker/setup-docker-action@v4
       - uses: docker/setup-compose-action@v1
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: qemu-utils
-          version: 1.0
+      - name: install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-utils guestfs-tools
 
       # Pull docker containers
       - name: pull docker containers

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 overlays/bennu/*.deb
 *.log
 *.vmdb
-./miniccc
-./minirouter
+miniccc
+minirouter
 *.qc2
 *.tar
+vyostmp
+scripts/vyos/vyos-build

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,12 @@ ntp:
 
 # Build vyos.qc2			-- VyOS 1.5
 vyos:
+	@set -e
 	@cd $(CURDIR)/scripts/vyos/
 	@VYOSTMP=$(VYOSTMP) ./build-vyos.sh -m $(CURDIR)/miniccc
 	@if command -v virt-sparsify >/dev/null 2>&1; then \
 		echo "virt-sparsify found — creating sparse copy to $(CURDIR)/vyos.qc2"; \
-		sudo virt-sparsify vyos.qc2 $(CURDIR)/vyos.qc2 && rm -f vyos.qc2 || { echo "virt-sparsify failed — falling back to move"; mv vyos.qc2 $(CURDIR); }; \
+		virt-sparsify vyos.qc2 $(CURDIR)/vyos.qc2 && rm -f vyos.qc2 || { echo "virt-sparsify failed — falling back to move"; mv vyos.qc2 $(CURDIR); }; \
 	else \
 		echo "virt-sparsify not found — not sparsifying, moving vyos.qc2"; \
 		mv vyos.qc2 $(CURDIR); \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,13 @@ ntp:
 vyos:
 	@cd $(CURDIR)/scripts/vyos/
 	@VYOSTMP=$(VYOSTMP) ./build-vyos.sh -m $(CURDIR)/miniccc
-	@mv vyos.qc2 $(CURDIR)
+	@if command -v virt-sparsify >/dev/null 2>&1; then \
+		echo "virt-sparsify found — creating sparse copy to $(CURDIR)/vyos.qc2"; \
+		sudo virt-sparsify vyos.qc2 $(CURDIR)/vyos.qc2 && rm -f vyos.qc2 || { echo "virt-sparsify failed — falling back to move"; mv vyos.qc2 $(CURDIR); }; \
+	else \
+		echo "virt-sparsify not found — not sparsifying, moving vyos.qc2"; \
+		mv vyos.qc2 $(CURDIR); \
+	fi
 
 # Build minirouter.qc2 		-- Ubuntu Noble, minirouter
 minirouter: _minirouter_img


### PR DESCRIPTION
# fix(vyos): revise phenix startup injects for latest vyos changes

## Description
At some point, vyos changed some of their overlay mounts and the phenix startup scripts were no longer being run.
This keeps the same inject path from the vrouter app, but updates the phenix startup script to execute the scripts from a location that seems to always be mounted reguardless over version: `/usr/lib/live/mount/persistence`.

This also simplifies the squashfs customization, leaving the versioned directories the same as the upstream vyos builder creates them. 

Finally, this adds some checks to the phenix startup script so that it exits silently if no startup scripts are present, and also create a flag (file) so that they are only executed once. This way users could make manual changes later during runtime and they won't get overridden on reboot by the startup script.

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
