### PR TITLE
feat: Add ot-sim/pandapower image

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -31,6 +31,7 @@ jobs:
             vyos,
             minirouter,
             ubuntu-soaptools,
+            ot-sim
           ]
     runs-on: ubuntu-latest
     steps:
@@ -124,6 +125,7 @@ jobs:
             vyos,
             minirouter,
             ubuntu-soaptools,
+            ot-sim
           ]
     # Only run on main branch for scheduled or manual workflow_dispatch events
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check_clean bookworm kali kali-harmonie jammy noble bennu minirouter _minirouter_img docker-hello-world ntp ubuntu-soaptools clean
+.PHONY: help check_clean bookworm kali kali-harmonie jammy noble bennu minirouter _minirouter_img docker-hello-world ntp ubuntu-soaptools clean ot-sim
 
 .ONESHELL: # for heredoc and exit
 
@@ -76,6 +76,13 @@ docker-hello-world:
 	@$(CHECK_IMAGE)
 	@$(PHENIX) image create -T $(CURDIR)/scripts/atomic/docker.sh $(UBUNTU_MIRROR) $(COMPRESS) $(@)
 	@$(PHENIX_IMAGE_BUILD) $(@)
+
+# Build ot-sim.qc2          -- Ubuntu Focal, OTSim, Pandas, 
+ot-sim:
+	@$(CHECK_IMAGE)
+	@$(PHENIX) image create -r focal -T $(CURDIR)/scripts/ot-sim.sh $(UBUNTU_MIRROR) $(COMPRESS) $(@)
+	@$(PHENIX_IMAGE_BUILD) $(@)
+	@$(INJECT_MINICCC)
 
 # Build ntp.qc2			-- Ubuntu Jammy, ntpd
 ntp:

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ the Makefile are shown below.
 | minirouter | Ubuntu / noble | miniccc/minirouter | Minimega-based router | :x: |
 | soaptools | Ubuntu / jammy | filebeat,zeek,msf | preconfigured image for the [soap-hil topology](https://github.com/sandialabs/sceptre-phenix-topologies/tree/main/soap-hil) | :white_check_mark:  |
 | kali-harmonie | Kali / kali-rolling | Scapy, pybind11, HELICS, pyOpenDNP3, elasticsearch-py | Kali Linux image for the HARMONIE-SPS LDRD. | :white_check_mark: |
-| OT-Sim | Ubuntu / focal | OT-Sim, PyPower, Pandas, pyOpenDNP3, HELICS | Ubuntu image for OT-SIM and Panda Power projects | :x: |
+| OT-Sim | Ubuntu / focal | OT-Sim, PandaPower, pyOpenDNP3, HELICS | Ubuntu image for OT-SIM and Panda Power projects | :x: |

--- a/README.md
+++ b/README.md
@@ -177,3 +177,4 @@ the Makefile are shown below.
 | minirouter | Ubuntu / noble | miniccc/minirouter | Minimega-based router | :x: |
 | soaptools | Ubuntu / jammy | filebeat,zeek,msf | preconfigured image for the [soap-hil topology](https://github.com/sandialabs/sceptre-phenix-topologies/tree/main/soap-hil) | :white_check_mark:  |
 | kali-harmonie | Kali / kali-rolling | Scapy, pybind11, HELICS, pyOpenDNP3, elasticsearch-py | Kali Linux image for the HARMONIE-SPS LDRD. | :white_check_mark: |
+| OT-Sim | Ubuntu / focal | OT-Sim, PyPower, Pandas, pyOpenDNP3, HELICS | Ubuntu image for OT-SIM and Panda Power projects | :x: |

--- a/scripts/ot-sim.sh
+++ b/scripts/ot-sim.sh
@@ -1,0 +1,65 @@
+set -ex
+
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Set timezone information
+ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
+
+apt-get install -y apt-utils
+
+# Install Man Pages
+apt-get install -y man-db manpages-dev
+
+# Install the OT-Sim/PandaPower APT Requirements
+apt-get install -y python3 python3-pip python2.7-dev python3-setuptools build-essential cmake libboost-dev libczmq-dev libxml2-dev libzmq5-dev pkg-config python3-dev python3-pip software-properties-common git
+
+# Install Go lang 1.21.8
+wget -O go.tgz https://golang.org/dl/go1.21.8.linux-amd64.tar.gz && tar -C /usr/local -xzf go.tgz && rm go.tgz && ln -s /usr/local/go/bin/* /usr/local/bin
+
+# Make move to /opt and git clone the ot-sim project
+cd /opt
+git clone https://github.com/patsec/ot-sim.git
+
+# Move into ot-sim
+cd /opt/ot-sim
+
+# Compile OT Sim
+cmake -S . -B build && sudo cmake --build build -j$(nproc) --target install && sudo ldconfig && sudo make -C src/go install
+
+# Compile OT Sim Python
+sudo python3 -m pip install src/python
+
+# Install Hivemind
+wget -O hivemind.gz https://github.com/DarthSim/hivemind/releases/download/v1.1.0/hivemind-v1.1.0-linux-amd64.gz
+gunzip hivemind.gz
+sudo mv hivemind /usr/local/bin/hivemind
+sudo chmod +x /usr/local/bin/hivemind
+
+# Install MBPoll
+wget -O- http://www.piduino.org/piduino-key.asc | sudo apt-key add -
+sudo add-apt-repository 'deb http://apt.piduino.org xenial piduino'
+sudo apt update
+sudo apt install mbpoll -y
+
+# Install OpenDSS
+sudo python3 -m pip install opendssdirect.py~=0.8.4
+
+# Install PandaPower Requirements
+sudo python3 -m pip install pandapower==2.14.11
+sudo python3 -m pip install pandas==2.0.3
+sudo python3 -m pip install numba==0.58.1
+
+# Change root password
+echo "root:SiaSd3te" | chpasswd
+
+# Add "sceptre" user set their login shell to bash
+adduser sceptre --UID 1001 --gecos "" --shell /bin/bash --disabled-login || true
+echo "sceptre:sceptre" | chpasswd
+
+#Ensure /etc is owned by root
+chown -R root:root /etc
+
+## Clean APT install
+apt-get -y clean || true


### PR DESCRIPTION
# Adding OT-Sim Image

## Description
Added `ot-sim.qc2` image for support of OT-Sim integration, image comes with Helics, OT-Sim, Pandas, PyPower. Pushing for reproducibility and use in ot-sim integrations to SCEPTRE.


## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
None
