### PR TITLE
fix(vyos): change vyos-build branch to 'rolling' to fix build

### DIFF
--- a/scripts/vyos/README.md
+++ b/scripts/vyos/README.md
@@ -1,14 +1,14 @@
 # VyOS Image Builder
 
 The `build-vyos.sh` script can be used to easily build a `vyos.qc2` VM image
-using the source code from the latest stable branch (currently `v1.5` -
-circinus).
+using the source code from the latest rolling branch of VyOS (currently `v1.5` -
+[Circinus](https://docs.vyos.io/en/rolling/introducing/history.html#circinus-1-5)).
 
-The script first uses a Docker image to build the qcow2 from source, then
-optionally uses a separate Docker image to inject the miniccc binary and set
-up the miniccc service to run at bootup.
+The script first uses a Docker image to build the qcow2 file from source, then
+optionally uses a separate Docker image to inject the `miniccc` binary and set
+up the `miniccc` service to run at bootup.
 
-The build_vyos() function was inspired by
+The `build_vyos()` function was inspired by
 [this forum post.](https://forum.vyos.io/t/build-for-qemu-or-vmware/15885/4)
 
 ## Usage

--- a/scripts/vyos/build-vyos.sh
+++ b/scripts/vyos/build-vyos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script will build a VyOS qcow2 image inside a docker container. The
-# VyOS version is set to 'current' and matches v1.5. Optionally, the full
+# VyOS version is set to 'rolling' and matches v1.5. Optionally, the full
 # path to a miniccc binary can be passed as another command line argument
 # and it will be injected into the final image, including a startup script
 # that runs on bootup. The final qcow2 image will be at: ./vyos.qc2
@@ -225,7 +225,7 @@ function build_vyos() {
 
     # fetch build files
     cd $CWD
-    git clone -b current --single-branch https://github.com/vyos/vyos-build
+    git clone -b rolling --single-branch https://github.com/vyos/vyos-build
     cd vyos-build
     git pull
 
@@ -240,13 +240,13 @@ packages = [$PACKAGES"qemu-guest-agent", "vim"]
 EOF
 
     # build vyos
-    docker pull ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:current
+    docker pull ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:rolling
     docker run --rm \
         -v /dev:/dev \
         -v $CWD/vyos-build:/root \
         -w /root --privileged \
         -e GOSU_UID="$(id -u)" -e GOSU_GID="$(id -g)" \
-        ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:current \
+        ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:rolling \
         bash -c "sudo make -j$(nproc) qemu"
 
     if [ -f "$MINICCC_PATH" ]; then


### PR DESCRIPTION
# fix(vyos): change vyos-build branch to 'rolling' to fix build

## Description

The 'current' branch was deleted from vyos-build, for reasons that are unclear. This updates the build to use the `rolling` branch.

## Related Issue
Closes #29

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
Currently testing locally, but mostly relying on Actions to test this fix.
