### PR TITLE
fix(vyos): increase VNC screen size

### DIFF
--- a/scripts/vyos/build-vyos.sh
+++ b/scripts/vyos/build-vyos.sh
@@ -51,6 +51,12 @@ cd \$BOOT_PATH/\$VERSION_DIR
 unsquashfs -dest \$ROOTFS \$SQUASHFS
 rm \$SQUASHFS # old fs
 
+# increase screen size to be less cramped for VNC
+# the "autoload" part of filename is important, so grub.cfg will source it
+tee \$BOOT_PATH/grub/grub.cfg.d/00-custom-gfx-autoload.cfg <<EOF
+set gfxpayload=1280x1024x32,auto
+EOF
+
 # branding
 tee \$ROOTFS/usr/share/vyos/templates/login/default_motd.j2 <<EOF
 ██████╗ ██╗  ██╗███████╗███╗  ██╗██╗██╗  ██╗


### PR DESCRIPTION
# fix(vyos): increase VNC screen size

## Description
Increase the display resolution for VyOS. This makes it less cramped and less painful to use.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A
